### PR TITLE
Make golang version an argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Multi-stage docker build for perkeep
-FROM golang:1.8-alpine as builder
+ARG GOLANG_VERSION=1.8
+FROM golang:${GOLANG_VERSION}-alpine as builder
 ARG PERKEEP_REF=8f1a7df176
 
 # Dependencies


### PR DESCRIPTION
To build a current version of Parkeep golang 1.9 is needed.
So making the version an argument would enable the build of new versions.

P.s.: Thanks a lot for your work, this saved me a lot of time.